### PR TITLE
Use errno from the standard library

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -37,29 +37,6 @@ extern {
     pub fn flock(fd: libc::c_int, operation: libc::c_int) -> libc::c_int;
 }
 
-#[cfg(target_os = "linux")]
-unsafe fn errno_location() -> *const libc::c_int {
-    extern { fn __errno_location() -> *const libc::c_int; }
-    __errno_location()
-}
-
-
-#[cfg(target_os = "openbsd")]
-unsafe fn errno_location() -> *const libc::c_int {
-    extern { fn __errno() -> *const libc::c_int; }
-    __errno()
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
-unsafe fn errno_location() -> *const libc::c_int {
-    extern { fn __error() -> *const libc::c_int; }
-    __error()
-}
-
-pub unsafe fn errno() -> libc::c_int {
-    *errno_location()
-}
-
 pub unsafe fn get_gid_by_name(name: &CString) -> Option<libc::gid_t> {
     let ptr = getgrnam(name.as_ptr() as *const libc::c_char);
     if ptr.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod ffi;
 extern crate libc;
 
 use std::fmt;
+use std::io;
 use std::env::{set_current_dir};
 use std::ffi::{CString};
 use std::os::unix::ffi::OsStringExt;
@@ -53,9 +54,9 @@ use std::path::{Path, PathBuf};
 use std::process::{exit};
 
 pub use libc::{uid_t, gid_t, mode_t};
-use libc::{LOCK_EX, LOCK_NB, c_int, fopen, write, close, fileno, fork, getpid, setsid, setuid, setgid, dup2, umask};
+use libc::{LOCK_EX, LOCK_NB, fopen, write, close, fileno, fork, getpid, setsid, setuid, setgid, dup2, umask};
 
-use self::ffi::{errno, flock, get_gid_by_name, get_uid_by_name};
+use self::ffi::{flock, get_gid_by_name, get_uid_by_name};
 
 macro_rules! tryret {
     ($expr:expr, $ret:expr, $err:expr) => (
@@ -67,7 +68,7 @@ macro_rules! tryret {
     )
 }
 
-pub type Errno = c_int;
+pub type Errno = i32;
 
 /// This error type for `Daemonize` `start` method.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -108,6 +109,10 @@ pub enum DaemonizeError {
     // could break existing code.
     #[doc(hidden)]
     __Nonexhaustive,
+}
+
+fn errno() -> Errno {
+    io::Error::last_os_error().raw_os_error().unwrap()
 }
 
 impl DaemonizeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,8 @@ pub enum DaemonizeError {
 }
 
 fn errno() -> Errno {
-    io::Error::last_os_error().raw_os_error().unwrap()
+    io::Error::last_os_error().raw_os_error()
+        .expect("last_os_error produces only OS errors hence raw_os_error cannot be None")
 }
 
 impl DaemonizeError {


### PR DESCRIPTION
Use the errno capabilities of the Rust standard library instead of having platform-specific code.

The code was grabbed from this PR: https://github.com/knsd/daemonize/pull/23
Since the author has deleted their repo, I just copy-pasted the code instead of picking the commit.